### PR TITLE
Create C-LSTM training function to predict binary class from nucleotide/AA sequence

### DIFF
--- a/ndac/data_processing.py
+++ b/ndac/data_processing.py
@@ -74,9 +74,40 @@ def value_classify(metric, sequences, high_value, low_value):
     return dataframe, hist
 
 
-def encode_sequence(sequences, metric_class=None, max_length=0):
+def documentize_sequence(seqs, tag, nt_seq):
+    """This function converts raw nucleotide or amino acid sequences
+    into documents that can be encoded with the Keras Tokenizer().
+    If a purification tag is supplied, it will be removed from
+    the sequence document. """
+    # setup 'docs' for use with Tokenizer
+    def seq_to_doc(seq):
+        # drop initial tag if it is supplied
+        if tag:
+            if tag not in seq:
+                return None
+            seq = seq.split(tag)[1]
+        # split the sequence at every letter if not a nt_seq
+        if not nt_seq:
+            return ' '.join([aa for aa in seq])
+        # split the sequence every 3 letters if it is a nt_seq
+        return ' '.join([seq[i:i + 3]
+                         for i in range(0, len(seq), 3)])
+
+    return seqs.apply(seq_to_doc)
+
+
+def encode_sequence(sequences, classes, max_length=0,
+                    tag=None, nt_seq=True):
+    dataframe = pd.concat([classes, sequences], axis=1)
+    # if there are more than 4 letters, we should treat as amino acid seq
+    if len(list(set(sequences[sequences.index[0]]))) > 4:
+        nt_seq = False
+    # turn sequence into documents for keras.Tokenizer()
+    dataframe['seq_doc'] = documentize_sequence(sequences, tag, nt_seq)
+    # drop sequences that weren't divisible by 3
+    dataframe = dataframe[pd.notnull(dataframe['seq_doc'])]
     # define sequence documents
-    docs = list(sequences)
+    docs = list(dataframe['seq_doc'])
     # create the tokenizer
     t = Tokenizer()
     # fit the tokenizer on the documents
@@ -86,9 +117,6 @@ def encode_sequence(sequences, metric_class=None, max_length=0):
     # pad or truncate sequences if max_length is nonzero
     if max_length:
         x = sequence.pad_sequences(x, maxlen=max_length)
-    # return x, y tuple of numpy arrays if class column is supplied
-    if metric_class:
-        y = metric_class.values
-        return x, y
-    # return numpy array of encoded sequences
-    return x
+    y = dataframe.loc[:, dataframe.columns[0]].values
+
+    return x, y

--- a/ndac/predict.py
+++ b/ndac/predict.py
@@ -10,7 +10,8 @@ from sklearn.model_selection import train_test_split
 
 
 def train_clstm(x, y, test_fraction=0, embedding_len=4,
-                batch_size=100, epochs=5, verbose=1):
+                batch_size=100, epochs=5, verbose=1,
+                save_file=None):
     # fix random seed for reproducibility
     np.random.seed(7)
     # get embedding parameters from x matrix
@@ -42,5 +43,8 @@ def train_clstm(x, y, test_fraction=0, embedding_len=4,
         # Final evaluation of the model
         scores = model.evaluate(x_test, y_test, verbose=0)
         print("Accuracy: %.2f%%" % (scores[1]*100))
+
+    if save_file:
+        model.save(save_file)
 
     return model

--- a/ndac/predict.py
+++ b/ndac/predict.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+from keras.models import Sequential
+from keras.layers import Dense
+from keras.layers import LSTM
+from keras.layers.embeddings import Embedding
+from sklearn.model_selection import train_test_split
+
+
+def train_clstm(x, y, test_fraction=0, embedding_len=4,
+                batch_size=100, epochs=5, verbose=1):
+    # fix random seed for reproducibility
+    np.random.seed(7)
+    # get embedding parameters from x matrix
+    vocab_size = x.max() + 1
+    seq_len = x.shape[1]
+
+    if test_fraction:
+        # create test-train split
+        x, x_test, y, y_test = train_test_split(x, y,
+                                                test_size=test_fraction)
+
+    # create the model
+    model = Sequential()
+    model.add(Embedding(input_dim=vocab_size,
+                        output_dim=embedding_len,
+                        input_length=seq_len))
+    model.add(LSTM(100))
+    model.add(Dense(1, activation='sigmoid'))
+    model.compile(loss='binary_crossentropy',
+                  optimizer='adam',
+                  metrics=['accuracy'])
+    print(model.summary())
+    model.fit(x, y, epochs=epochs,
+              batch_size=batch_size, verbose=verbose)
+    # report the test accuracy if we performed a train_test_split
+    if test_fraction:
+        # Final evaluation of the model
+        scores = model.evaluate(x_test, y_test, verbose=0)
+        print("Accuracy: %.2f%%" % (scores[1]*100))
+
+    return model

--- a/ndac/predict.py
+++ b/ndac/predict.py
@@ -4,6 +4,8 @@ from keras.models import Sequential
 from keras.layers import Dense
 from keras.layers import LSTM
 from keras.layers.embeddings import Embedding
+from keras.layers.convolutional import Conv1D
+from keras.layers.convolutional import MaxPooling1D
 from sklearn.model_selection import train_test_split
 
 
@@ -25,6 +27,8 @@ def train_clstm(x, y, test_fraction=0, embedding_len=4,
     model.add(Embedding(input_dim=vocab_size,
                         output_dim=embedding_len,
                         input_length=seq_len))
+    model.add(Conv1D(filters=128, kernel_size=3, padding='same', activation='selu'))
+    model.add(MaxPooling1D(pool_size=2))
     model.add(LSTM(100))
     model.add(Dense(1, activation='sigmoid'))
     model.compile(loss='binary_crossentropy',

--- a/train_clstm_example.ipynb
+++ b/train_clstm_example.ipynb
@@ -1,0 +1,197 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/joshsmith/Git/NovoNordisk_Capstone/.env/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.\n",
+      "  from ._conv import register_converters as _register_converters\n",
+      "Using TensorFlow backend.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "from ndac.data_processing import quantile_classify, encode_sequence\n",
+    "from ndac.predict import train_clstm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# read in sequence/property data\n",
+    "data = pd.read_csv('dataframes/DF_prest.csv', index_col=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# train with nucleotide seq"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "45206 samples input.\n",
+      "11303 samples above high cut, 11302 samples below low cut, 22601 samples removed.\n",
+      "WARNING:tensorflow:From /Users/joshsmith/Git/NovoNordisk_Capstone/.env/lib/python3.6/site-packages/tensorflow/python/util/deprecation.py:497: calling conv1d (from tensorflow.python.ops.nn_ops) with data_format=NHWC is deprecated and will be removed in a future version.\n",
+      "Instructions for updating:\n",
+      "`NHWC` for data_format is deprecated, use `NWC` instead\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "embedding_1 (Embedding)      (None, 200, 4)            296       \n",
+      "_________________________________________________________________\n",
+      "conv1d_1 (Conv1D)            (None, 200, 128)          1664      \n",
+      "_________________________________________________________________\n",
+      "max_pooling1d_1 (MaxPooling1 (None, 100, 128)          0         \n",
+      "_________________________________________________________________\n",
+      "lstm_1 (LSTM)                (None, 100)               91600     \n",
+      "_________________________________________________________________\n",
+      "dense_1 (Dense)              (None, 1)                 101       \n",
+      "=================================================================\n",
+      "Total params: 93,661\n",
+      "Trainable params: 93,661\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n",
+      "None\n",
+      "Epoch 1/3\n",
+      "15678/15678 [==============================] - 25s 2ms/step - loss: 0.6823 - acc: 0.5536\n",
+      "Epoch 2/3\n",
+      "15678/15678 [==============================] - 24s 2ms/step - loss: 0.6507 - acc: 0.6272\n",
+      "Epoch 3/3\n",
+      "15678/15678 [==============================] - 24s 2ms/step - loss: 0.6423 - acc: 0.6343\n",
+      "Accuracy: 63.88%\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAD8CAYAAAB+UHOxAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAGzRJREFUeJzt3X+QHOV95/H3N8hgYDn9QPGik1RZbFSuIuhMpD3EnX2u3cgHAoPlSwgBq4yEZa9dFj58UcrI+BLp/ONOXI4YjB3CYqkQOcJCsB0JWRgrsvZcvopkJAVYAcYsRARtCSkgsWaNErK+7/3Rz47by8zuzPRO9+w+n1fV1D7z9NPT36dndr7Tz9PTY+6OiIjE59eKDkBERIqhBCAiEiklABGRSCkBiIhESglARCRSSgAiIpFSAhARidS4CcDMNpvZMTM7WGbZWjNzM5sd7puZfc3M+s3sSTNblGq70syeC7eVE9sNERGpVTVHAPcAy0ZXmtl84BLgH1LVlwELwq0LuDO0nQWsB5YAFwHrzWxmlsBFRCSbaeM1cPcfmllbmUVfBT4HbE3VLQfu9eTrxXvMbIaZzQE6gJ3ufhzAzHaSJJX7x9r27Nmzva2t3Kar8/Of/5wzzzyz7vUbpdq4BgcHS+Xp06c3MiSgSfZXqs+EPjdFXGUortoortpkiWv//v2vuPuvj9du3ARQjpktBwbc/QkzSy+aC7yUun841FWqH1NbWxv79u2rJ0QAent76ejoqHv9Rqk2rvS+zeOSHU2xv9Kvp9DnpoirDMVVG8VVmyxxmdmL1bSrOQGY2RnAzSTDPxPOzLpIho9obW2lt7e37scaGhrKtH6j1BNXHv1ohv3VkSqPxNIMcZWjuGqjuGqTS1zuPu4NaAMOhvJC4BhwKNyGSeYBzgHuAq5NrfcsMAe4FrgrVf8r7SrdFi9e7Fns3r070/qNUm1cQOmWh6bYX8nn/uQWNEVcZSiu2iiu2mSJC9jnVby313waqLv3ufs73L3N3dtIhnMWufvLwDbgunA20MXAoLsfAR4FLjGzmWHy95JQJyIiBanmNND7gb8F3m1mh81s9RjNdwAvAP3A3cCnATyZ/P0S8Fi4fTHUiYhIQao5C+jacZa3pcoOrKnQbjOwucb4RESkQfRNYBGRSCkBiIhESglARCRSSgAiIpGq65vAko9FixaN36jJta37bql8aOMHx19hCvRZZLJQAmhi+/fvLzqE/MXYZ5GCaAhIRCRSSgAiIpFSAhARiZTmAJpYd3d3qdzV1VVgJDlK9ZlY+ixSECWAJvbJT36yVG6WBFDNWT3pNjVL9VkJQKSxlABkXJne0EWkaWkOQEQkUjoCkAmhowSRyUdHACIikVICEBGJlBKAiEikNAcgZVUzpq9xf5HJTUcAIiKRUgIQEYmUhoCa2BVXXFF0CPmLsc8iBVECaGIPP/xw0SHkL8Y+ixRk3CEgM9tsZsfM7GCq7k/M7Cdm9qSZfcfMZqSWfd7M+s3sWTO7NFW/LNT1m9m6ie+KZNU3MEjbuu9qclckEtXMAdwDLBtVtxO4wN3/DfBT4PMAZnY+cA3wm2GdPzOzU8zsFOAbwGXA+cC1oa1EZCS5KMGINIdxE4C7/xA4Pqru++4+HO7uAeaF8nKgx93/2d3/HugHLgq3fnd/wd3fBHpCWxERKchEzAF8DHgglOeSJIQRh0MdwEuj6pdMwLantA0bNpQtT2npfsbSZ5GCmLuP38isDdju7heMqv8C0A78jru7mX0d2OPu/zss3wQ8Epovc/ePh/qPAkvc/YYy2+oCugBaW1sX9/T01Nk1GBoaoqWlpe71G6XauDo7O0vl3bt3Z9pm38Bgqbxw7vSybY4dH+ToyUybqUs6no5Un3tDnyf785g3xVWbqRhXZ2fnfndvH69d3UcAZrYKuAJY6r/MIgPA/FSzeaGOMep/hbt3A90A7e3t3tHRUW+I9Pb2kmX9Rqknrqz9WJX+IZcV5R/rjvu2cmtf/ieGVYpnpM9T6XnMg+KqTcxx1fVFMDNbBnwO+JC7v5FatA24xsxOM7NzgQXAj4HHgAVmdq6ZnUoyUbwtW+giIpLFuB/3zOx+oAOYbWaHgfUkZ/2cBuw0M0iGfT7l7k+Z2YPA08AwsMbdfxEe5wbgUeAUYLO7P9WA/oiISJXGTQDufm2Z6k1jtP8K8JUy9TuAHTVFJyIiDaNrAYmIREoJQEQkUkoAIiKRUgIQEYmUEoCISKR0Oegm9olPfKLoEPIXY59FCqIE0MS6u7uLDiEX6auDHoqkzyLNQAkgcuk337ULCwxERHKnBBAhXY9fRECTwCIi0dIRQBPr6uoqlWOZD/jLC3/543M3L/sMAGsXDtNRUDwiU5kSQBO7++67S+VYEsBHnni0VB5JACLSGBoCEhGJlBKAiEiklABERCKlBCAiEiklABGRSCkBiIhESglARCRSSgAiIpHSF8GmMF3zR0TGogTQxNavX190CLm77b3XFh2CSDTGTQBmthm4Ajjm7heEulnAA0AbcAi42t1PmJkBtwOXA28Aq9z9QFhnJfBfw8N+2d23TGxXpp4NGzYUHULubnvfiqJDEIlGNXMA9wDLRtWtA3a5+wJgV7gPcBmwINy6gDuhlDDWA0uAi4D1ZjYza/AiIlK/cROAu/8QOD6qejkw8gl+C/DhVP29ntgDzDCzOcClwE53P+7uJ4CdvDWpiIhIjszdx29k1gZsTw0BvebuM0LZgBPuPsPMtgMb3f1HYdku4CagA3i7u3851P8RcNLd/1eZbXWRHD3Q2tq6uKenp+7ODQ0N0dLSUvf6jZJXXH0DgzW1bz0djp5sUDAZtJ4O75g1vegw3iL211etFFdtssTV2dm5393bx2uXeRLY3d3Mxs8i1T9eN9AN0N7e7h0dHXU/Vm9vL1nWb5Rq47ryyitL5Ycffrjm7ayq8SygtQuHubWv2PMCvvnQfyuVP35VMgm+duEwV0/i5zFviqs2McdV73/7UTOb4+5HwhDPsVA/AMxPtZsX6gbgV37TYx7QW+e2o7F9+/aiQ8jdB55/rOgQRKJR7xfBtgErQ3klsDVVf50lLgYG3f0I8ChwiZnNDJO/l4Q6EREpSDWngd5P8ul9tpkdJjmbZyPwoJmtBl4Erg7Nd5CcAtpPchro9QDuftzMvgSMfLz7oruPnlgWEZEcjZsA3L3SN3OWlmnrwJoKj7MZ2FxTdCIi0jC6FpCISKSUAEREIqUEICISKSUAEZFIKQGIiERKCUBEJFL6PYAmdtdddxUdQu4+f+kNZevTP25zaOMH8wpHZEpTAmhiXV1dRYeQu/sv1EViRfKiISARkUjpCGCK0e8Ai0i1lAAmIY2Hi8hEUAJoYosXLy6V9+/fX2Ak+Xn4nhtL5StX3V5gJCJTnxJAEztw4EDRIeRu4dHniw5BJBqaBBYRiZSOAGTS0RyIyMRQApjkdNaPiNRLQ0AiIpFSAhARiZQSgIhIpDQHIJOaJoRF6qcjABGRSCkBiIhEKtMQkJn9F+DjgAN9wPXAHKAHOBvYD3zU3d80s9OAe4HFwKvA77v7oSzbn+q2bdtWdAi5W/27f1R0CCLRqDsBmNlc4D8D57v7STN7ELgGuBz4qrv3mNmfA6uBO8PfE+5+npldA9wC/H7mHkxhV155ZdEh5G7XeUuKDkEkGlkngacBp5vZvwBnAEeA3wY+EpZvATaQJIDloQzwEPB1MzN394wxREFf+BKRiWZZ3n/N7EbgK8BJ4PvAjcAedz8vLJ8PPOLuF5jZQWCZux8Oy54Hlrj7K6MeswvoAmhtbV3c09NTd3xDQ0O0tLTUvX6jVBtX38BgDtH8UuvpcPRkrpusSrVxLZw7vfHBpEz211feFFdtssTV2dm5393bx2uXZQhoJsmn+nOB14C/AjL/np+7dwPdAO3t7d7R0VH3Y/X29pJl/UYZHVelUxlX5fypf+3CYW7ta74zg6uN69CKjsYHkzJZXl/NQnHVJo+4svy3fwD4e3f/RwAz+zbwXmCGmU1z92FgHjAQ2g8A84HDZjYNmE4yGRylaoZ0Dn/julJ53pp7GxlO09ib6vOSSPosUpQsCeAfgIvN7AySIaClwD5gN3AVyZlAK4Gtof22cP9vw/IfaPx/bL8YOl50CLlrjbDPIkWp+3sA7r6XZDL3AMkpoL9GMnRzE/AHZtZPciroprDKJuDsUP8HwLoMcYuISEaZBnzdfT2wflT1C8BFZdr+E/B7WbYnIiITp/lm/CKn0z1FJC+6FISISKSUAEREIqUhoAoqDcVUc8nhLOuKiORFRwAiIpHSEUCORo4M1i4cRrteRIqmIwARkUjpY2gTO2flbUWHkLsrIuyzSFGUAJrYaeecV3QIuTuYoc+jJ9816S4yNiWACaIvcInIZKMEUKNKl24WEZlslABS9CleRGISfQJo5jf9F2+5olT+jZu2FxhJfg6l+twWSZ9FihJ9AsiimZOHiMh49D0AEZFI6QhApixN2IuMTUcAIiKRivIIQGP3IiI6AhARiZYSgIhIpJQAREQipQQgIhKpTJPAZjYD+CZwAeDAx4BngQeANuAQcLW7nzAzA24HLgfeAFa5+4Es2xeplk4JFXmrrGcB3Q58z92vMrNTgTOAm4Fd7r7RzNYB64CbgMuABeG2BLgz/JUK5n56S9Eh5O6iCPssUpS6E4CZTQfeD6wCcPc3gTfNbDnQEZptAXpJEsBy4F53d2CPmc0wsznufqTu6Ke4aWedXXQIuTsWYZ9FimLJ+3EdK5pdCHQDTwPvAfYDNwID7j4jtDHghLvPMLPtwEZ3/1FYtgu4yd33jXrcLqALoLW1dXFPT09d8QEMDQ3R0tLylvq+gcG6H3MitJ4OR08WGkJZscS1cO70CXmcSq+voimu2kzFuDo7O/e7e/t47bIMAU0DFgGfcfe9ZnY7yXBPibu7mdWUYdy9mySx0N7e7h0dHXUH2NvbS7n1VxX8RbC1C4e5ta/5voMXS1yHVnRMyONUen0VTXHVJua4spwFdBg47O57w/2HSBLCUTObAxD+HgvLB4D5qfXnhTqpYPj1V0u3WLzj9VdLNxFprLo/Vrn7y2b2kpm9292fBZaSDAc9DawENoa/W8Mq24AbzKyHZPJ3UOP/Yxv4s5Wlciy/B/DjVJ/1ewAijZX1uPozwH3hDKAXgOtJjioeNLPVwIvA1aHtDpJTQPtJTgO9PuO2RUQkg0wJwN0fB8pNNCwt09aBNVm2JyIiE0ffBBYRiZQSgIhIpJQAREQipQQgIhIpJQARkUgpAYiIREoJQEQkUs134ReRBtNvA4gklACaWCyXf0jT5R9E8qMhIBGRSCkBiIhESglARCRSmgNoYv/8cn+pfNo55xUYSX4uSPX5YCR9FimKEkATe3nLZ0vlWCaEt6f6rAlhkcZSApCo6ZRQiZnmAEREIqUEICISKSUAEZFIRTMHkB7rFRERHQGIiERLCUBEJFKZE4CZnWJmf2dm28P9c81sr5n1m9kDZnZqqD8t3O8Py9uybltEROo3EUcANwLPpO7fAnzV3c8DTgCrQ/1q4ESo/2po11B9A4O0rfuuxv9FRMrIlADMbB7wQeCb4b4Bvw08FJpsAT4cysvDfcLypaG9VHBKy6zSLRZHW2aVbiLSWFnPAroN+BxwVrh/NvCauw+H+4eBuaE8F3gJwN2HzWwwtH8lYwxT1rw19xYdQu6WFNhnfStYYmPuXt+KZlcAl7v7p82sA/hDYBWwJwzzYGbzgUfc/QIzOwgsc/fDYdnzwBJ3f2XU43YBXQCtra2Le3p66ooP4NjxQY6erHv1hmk9HcVVg6LjWjh3etn6oaEhWlpaco5mfIqrNlMxrs7Ozv3u3j5euyxHAO8FPmRmlwNvB/4VcDsww8ymhaOAecBAaD8AzAcOm9k0YDrw6ugHdfduoBugvb3dOzo66g7wjvu2cmtf833VYe3CYcVVg6LjOrSio2x9b28vWV6fjaK4ahNzXHXPAbj75919nru3AdcAP3D3FcBu4KrQbCWwNZS3hfuE5T/weg8/REQks0Z8rLoJ6DGzLwN/B2wK9ZuAvzCzfuA4SdKQMbzRv7dUPuO8JQVGkp+lqT7viqTPIkWZkATg7r1Abyi/AFxUps0/Ab83EduLxT9+60ulciy/B7Ap1Wf9HoBIY+mbwCIikVICEBGJlBKAiEiklABERCKlBCAiEiklABGRSCkBiIhESglARCRSzXfhF5Emo6uEylSlBNDETm19V9Eh5K4vwj6LFEUJoInNWXV70SHk7spJ1Oe+gUFWhaMDHRnIZKQ5ABGRSCkBiIhESglARCRSmgNoYq8//r1S+awLlxUYSX6uTfX5/kj6LFIUJYAmdvzRr5fKsSSA/5HqczMmgPQpoWsXFhiIyATQEJCISKSUAEREIqUEICISKSUAEZFIaRJYZALoekEyGekIQEQkUnUnADObb2a7zexpM3vKzG4M9bPMbKeZPRf+zgz1ZmZfM7N+M3vSzBZNVCdERKR2WY4AhoG17n4+cDGwxszOB9YBu9x9AbAr3Ae4DFgQbl3AnRm2LSIiGdWdANz9iLsfCOXXgWeAucByYEtotgX4cCgvB+71xB5ghpnNqTtyERHJZEImgc2sDfgtYC/Q6u5HwqKXgdZQngu8lFrtcKg7gpR1+rv+bdEh5O5vpkCfNSEsk4W5e7YHMGsB/g/wFXf/tpm95u4zUstPuPtMM9sObHT3H4X6XcBN7r5v1ON1kQwR0draurinp6fu2I4dH+ToybpXb5jW01FcNZjMcS2cOz2fYFKGhoZoaWnJfbvjUVy1yRJXZ2fnfndvH69dpiMAM3sb8C3gPnf/dqg+amZz3P1IGOI5FuoHgPmp1eeFul/h7t1AN0B7e7t3dHTUHd8d923l1r7mO9N17cJhxVWDyRzXoRUd+QST0tvbS5b/m0ZRXLXJI64sZwEZsAl4xt3/NLVoG7AylFcCW1P114WzgS4GBlNDRSIikrMsH6veC3wU6DOzx0PdzcBG4EEzWw28CFwdlu0ALgf6gTeA6zNsW0REMqo7AYSxfKuweGmZ9g6sqXd7MXrtR/eVyjPet6LASPLz2VSfb4ukzyJFab6BVSkZ/L/3l8rRJIBUn6dCAtAZQdLMdCkIEZFIKQGIiERKQ0AiOUkPB6VpaEiKoiMAEZFIKQGIiERKCUBEJFKaAxBpIjptVPKkBCBSsEqTwyKNpiEgEZFI6QigibW859KiQ8jdX0bYZ5GiKAE0sbOXfaboEHJ3c4R9rkTzAdJoGgISEYmUEoCISKQ0BCQyCWg4SBpBCaCJvfq9O0rlWOYD/nuqz5oPKE/JQCaKEkATG3ri0VI5lgTwkVSflQDGp2QgWSgBiExBSgxSDSUAkSli5E1/7cJhxvrXVnKQEUoAIlOcLjUhlSgBiAigI4MYKQGIRKyaowP9ktnUlXsCMLNlwO3AKcA33X1j3jGIyNgmKjGk29yz7MzsgcmEyjUBmNkpwDeA/wgcBh4zs23u/nSecYhI41RKDH0Dg6wKyyolibQYjzDyTph5HwFcBPS7+wsAZtYDLAeUAEQikuUII62aJFFpbiN91tSqdd+NMuHknQDmAi+l7h8GluQcg4hMEbWe4TRW+0acLVXNkU6RzN3z25jZVcAyd/94uP9RYIm735Bq0wV0hbvvBp7NsMnZwCsZ1m8UxVUbxVUbxVWbqRjXb7j7r4/XKO8jgAFgfur+vFBX4u7dQPdEbMzM9rl7+0Q81kRSXLVRXLVRXLWJOa68Lwf9GLDAzM41s1OBa4BtOccgIiLkfATg7sNmdgPwKMlpoJvd/ak8YxARkUTu3wNw9x3Ajpw2NyFDSQ2guGqjuGqjuGoTbVy5TgKLiEjz0E9CiohEatInADNbZmbPmlm/ma0rs/w0M3sgLN9rZm05xDTfzHab2dNm9pSZ3VimTYeZDZrZ4+H2x42OK7XtQ2bWF7a7r8xyM7OvhX32pJktyiGmd6f2xeNm9jMz++yoNrnsMzPbbGbHzOxgqm6Wme00s+fC35kV1l0Z2jxnZitziOtPzOwn4Xn6jpnNqLDumM95A+LaYGYDqefq8grrjvn/24C4HkjFdMjMHq+wbiP3V9n3h0JeY+4+aW8kE8nPA+8ETgWeAM4f1ebTwJ+H8jXAAznENQdYFMpnAT8tE1cHsL2g/XYImD3G8suBRwADLgb2FvC8vkxyLnPu+wx4P7AIOJiq+5/AulBeB9xSZr1ZwAvh78xQntnguC4BpoXyLeXiquY5b0BcG4A/rOJ5HvP/d6LjGrX8VuCPC9hfZd8finiNTfYjgNKlJdz9TWDk0hJpy4EtofwQsNTMrJFBufsRdz8Qyq8Dz5B8C3qyWA7c64k9wAwzm5Pj9pcCz7v7izlus8TdfwgcH1Wdfh1tAT5cZtVLgZ3uftzdTwA7gWWNjMvdv+/uw+HuHpLv1uSqwv6qRjX/vw2JK7wHXA3cP1Hbq9YY7w+5v8YmewIod2mJ0W+0pTbhH2UQODuX6IAw5PRbwN4yi/+dmT1hZo+Y2W/mFRPgwPfNbH/45vVo1ezXRrqGyv+YRe2zVnc/EsovA61l2hS93z5GcuRWznjPeSPcEIamNlcYzihyf/0H4Ki7P1dheS77a9T7Q+6vscmeAJqambUA3wI+6+4/G7X4AMkQx3uAO4C/zjG097n7IuAyYI2ZvT/HbY/Jki8Ifgj4qzKLi9xnJZ4cizfV6XNm9gVgGLivQpO8n/M7gXcBFwJHSIZbmsm1jP3pv+H7a6z3h7xeY5M9AYx7aYl0GzObBkwHXm10YGb2NpIn9z53//bo5e7+M3cfCuUdwNvMbHaj4wrbGwh/jwHfITkUT6tmvzbKZcABdz86ekGR+ww4OjIMFv4eK9OmkP1mZquAK4AV4Y3jLap4zieUux9191+4+/8D7q6wvaL21zTgd4AHKrVp9P6q8P6Q+2tssieAai4tsQ0YmSm/CvhBpX+SiRLGFzcBz7j7n1Zoc87IXISZXUTyXOSRmM40s7NGyiSTiAdHNdsGXGeJi4HB1KFpo1X8ZFbUPgvSr6OVwNYybR4FLjGzmWHI45JQ1zCW/MDS54APufsbFdpU85xPdFzpOaP/VGF7RV0a5gPAT9z9cLmFjd5fY7w/5P8aa8Qsd543kjNWfkpyNsEXQt0XSf4hAN5OMpzQD/wYeGcOMb2P5PDtSeDxcLsc+BTwqdDmBuApkjMf9gD/Pqf99c6wzSfC9kf2WTo2I/nhnueBPqA9p9jOJHlDn56qy32fkSSgI8C/kIyxriaZN9oFPAf8DTArtG0n+WW7kXU/Fl5r/cD1OcTVTzImPPI6Gznj7V8DO8Z6zhsc11+E186TJG9sc0bHFe6/5f+3kXGF+ntGXlOptnnur0rvD7m/xvRNYBGRSE32ISAREamTEoCISKSUAEREIqUEICISKSUAEZFIKQGIiERKCUBEJFJKACIikfr/Rt25lhY0GnwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# split quantiles and encode with nucleotide sequence\n",
+    "df, hist = quantile_classify(data['conc_cf'], data['nt_seq'])\n",
+    "X, y = encode_sequence(df['nt_seq'], df['class'],\n",
+    "                       max_length=200, tag='GACAAGCTTGCGGCCGCA')\n",
+    "\n",
+    "nt_model = train_clstm(X, y, test_fraction=0.3, \n",
+    "                       epochs=3, save_file='nt_model.h5')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# train with nucleotide sequence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "45206 samples input.\n",
+      "11303 samples above high cut, 11302 samples below low cut, 22601 samples removed.\n",
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "embedding_3 (Embedding)      (None, 200, 4)            84        \n",
+      "_________________________________________________________________\n",
+      "conv1d_3 (Conv1D)            (None, 200, 128)          1664      \n",
+      "_________________________________________________________________\n",
+      "max_pooling1d_3 (MaxPooling1 (None, 100, 128)          0         \n",
+      "_________________________________________________________________\n",
+      "lstm_3 (LSTM)                (None, 100)               91600     \n",
+      "_________________________________________________________________\n",
+      "dense_3 (Dense)              (None, 1)                 101       \n",
+      "=================================================================\n",
+      "Total params: 93,449\n",
+      "Trainable params: 93,449\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n",
+      "None\n",
+      "Epoch 1/3\n",
+      "15823/15823 [==============================] - 25s 2ms/step - loss: 0.7301 - acc: 0.5196\n",
+      "Epoch 2/3\n",
+      "15823/15823 [==============================] - 25s 2ms/step - loss: 0.6864 - acc: 0.5410\n",
+      "Epoch 3/3\n",
+      "15823/15823 [==============================] - 25s 2ms/step - loss: 0.6733 - acc: 0.5814\n",
+      "Accuracy: 61.01%\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAD8CAYAAAB+UHOxAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAGzRJREFUeJzt3X+QHOV95/H3N8hgYDn9QPGik1RZbFSuIuhMpD3EnX2u3cgHAoPlSwgBq4yEZa9dFj58UcrI+BLp/ONOXI4YjB3CYqkQOcJCsB0JWRgrsvZcvopkJAVYAcYsRARtCSkgsWaNErK+7/3Rz47by8zuzPRO9+w+n1fV1D7z9NPT36dndr7Tz9PTY+6OiIjE59eKDkBERIqhBCAiEiklABGRSCkBiIhESglARCRSSgAiIpFSAhARidS4CcDMNpvZMTM7WGbZWjNzM5sd7puZfc3M+s3sSTNblGq70syeC7eVE9sNERGpVTVHAPcAy0ZXmtl84BLgH1LVlwELwq0LuDO0nQWsB5YAFwHrzWxmlsBFRCSbaeM1cPcfmllbmUVfBT4HbE3VLQfu9eTrxXvMbIaZzQE6gJ3ufhzAzHaSJJX7x9r27Nmzva2t3Kar8/Of/5wzzzyz7vUbpdq4BgcHS+Xp06c3MiSgSfZXqs+EPjdFXGUortoortpkiWv//v2vuPuvj9du3ARQjpktBwbc/QkzSy+aC7yUun841FWqH1NbWxv79u2rJ0QAent76ejoqHv9Rqk2rvS+zeOSHU2xv9Kvp9DnpoirDMVVG8VVmyxxmdmL1bSrOQGY2RnAzSTDPxPOzLpIho9obW2lt7e37scaGhrKtH6j1BNXHv1ohv3VkSqPxNIMcZWjuGqjuGqTS1zuPu4NaAMOhvJC4BhwKNyGSeYBzgHuAq5NrfcsMAe4FrgrVf8r7SrdFi9e7Fns3r070/qNUm1cQOmWh6bYX8nn/uQWNEVcZSiu2iiu2mSJC9jnVby313waqLv3ufs73L3N3dtIhnMWufvLwDbgunA20MXAoLsfAR4FLjGzmWHy95JQJyIiBanmNND7gb8F3m1mh81s9RjNdwAvAP3A3cCnATyZ/P0S8Fi4fTHUiYhIQao5C+jacZa3pcoOrKnQbjOwucb4RESkQfRNYBGRSCkBiIhESglARCRSSgAiIpGq65vAko9FixaN36jJta37bql8aOMHx19hCvRZZLJQAmhi+/fvLzqE/MXYZ5GCaAhIRCRSSgAiIpFSAhARiZTmAJpYd3d3qdzV1VVgJDlK9ZlY+ixSECWAJvbJT36yVG6WBFDNWT3pNjVL9VkJQKSxlABkXJne0EWkaWkOQEQkUjoCkAmhowSRyUdHACIikVICEBGJlBKAiEikNAcgZVUzpq9xf5HJTUcAIiKRUgIQEYmUhoCa2BVXXFF0CPmLsc8iBVECaGIPP/xw0SHkL8Y+ixRk3CEgM9tsZsfM7GCq7k/M7Cdm9qSZfcfMZqSWfd7M+s3sWTO7NFW/LNT1m9m6ie+KZNU3MEjbuu9qclckEtXMAdwDLBtVtxO4wN3/DfBT4PMAZnY+cA3wm2GdPzOzU8zsFOAbwGXA+cC1oa1EZCS5KMGINIdxE4C7/xA4Pqru++4+HO7uAeaF8nKgx93/2d3/HugHLgq3fnd/wd3fBHpCWxERKchEzAF8DHgglOeSJIQRh0MdwEuj6pdMwLantA0bNpQtT2npfsbSZ5GCmLuP38isDdju7heMqv8C0A78jru7mX0d2OPu/zss3wQ8Epovc/ePh/qPAkvc/YYy2+oCugBaW1sX9/T01Nk1GBoaoqWlpe71G6XauDo7O0vl3bt3Z9pm38Bgqbxw7vSybY4dH+ToyUybqUs6no5Un3tDnyf785g3xVWbqRhXZ2fnfndvH69d3UcAZrYKuAJY6r/MIgPA/FSzeaGOMep/hbt3A90A7e3t3tHRUW+I9Pb2kmX9Rqknrqz9WJX+IZcV5R/rjvu2cmtf/ieGVYpnpM9T6XnMg+KqTcxx1fVFMDNbBnwO+JC7v5FatA24xsxOM7NzgQXAj4HHgAVmdq6ZnUoyUbwtW+giIpLFuB/3zOx+oAOYbWaHgfUkZ/2cBuw0M0iGfT7l7k+Z2YPA08AwsMbdfxEe5wbgUeAUYLO7P9WA/oiISJXGTQDufm2Z6k1jtP8K8JUy9TuAHTVFJyIiDaNrAYmIREoJQEQkUkoAIiKRUgIQEYmUEoCISKR0Oegm9olPfKLoEPIXY59FCqIE0MS6u7uLDiEX6auDHoqkzyLNQAkgcuk337ULCwxERHKnBBAhXY9fRECTwCIi0dIRQBPr6uoqlWOZD/jLC3/543M3L/sMAGsXDtNRUDwiU5kSQBO7++67S+VYEsBHnni0VB5JACLSGBoCEhGJlBKAiEiklABERCKlBCAiEiklABGRSCkBiIhESglARCRSSgAiIpHSF8GmMF3zR0TGogTQxNavX190CLm77b3XFh2CSDTGTQBmthm4Ajjm7heEulnAA0AbcAi42t1PmJkBtwOXA28Aq9z9QFhnJfBfw8N+2d23TGxXpp4NGzYUHULubnvfiqJDEIlGNXMA9wDLRtWtA3a5+wJgV7gPcBmwINy6gDuhlDDWA0uAi4D1ZjYza/AiIlK/cROAu/8QOD6qejkw8gl+C/DhVP29ntgDzDCzOcClwE53P+7uJ4CdvDWpiIhIjszdx29k1gZsTw0BvebuM0LZgBPuPsPMtgMb3f1HYdku4CagA3i7u3851P8RcNLd/1eZbXWRHD3Q2tq6uKenp+7ODQ0N0dLSUvf6jZJXXH0DgzW1bz0djp5sUDAZtJ4O75g1vegw3iL211etFFdtssTV2dm5393bx2uXeRLY3d3Mxs8i1T9eN9AN0N7e7h0dHXU/Vm9vL1nWb5Rq47ryyitL5Ycffrjm7ayq8SygtQuHubWv2PMCvvnQfyuVP35VMgm+duEwV0/i5zFviqs2McdV73/7UTOb4+5HwhDPsVA/AMxPtZsX6gbgV37TYx7QW+e2o7F9+/aiQ8jdB55/rOgQRKJR7xfBtgErQ3klsDVVf50lLgYG3f0I8ChwiZnNDJO/l4Q6EREpSDWngd5P8ul9tpkdJjmbZyPwoJmtBl4Erg7Nd5CcAtpPchro9QDuftzMvgSMfLz7oruPnlgWEZEcjZsA3L3SN3OWlmnrwJoKj7MZ2FxTdCIi0jC6FpCISKSUAEREIqUEICISKSUAEZFIKQGIiERKCUBEJFL6PYAmdtdddxUdQu4+f+kNZevTP25zaOMH8wpHZEpTAmhiXV1dRYeQu/sv1EViRfKiISARkUjpCGCK0e8Ai0i1lAAmIY2Hi8hEUAJoYosXLy6V9+/fX2Ak+Xn4nhtL5StX3V5gJCJTnxJAEztw4EDRIeRu4dHniw5BJBqaBBYRiZSOAGTS0RyIyMRQApjkdNaPiNRLQ0AiIpFSAhARiZQSgIhIpDQHIJOaJoRF6qcjABGRSCkBiIhEKtMQkJn9F+DjgAN9wPXAHKAHOBvYD3zU3d80s9OAe4HFwKvA77v7oSzbn+q2bdtWdAi5W/27f1R0CCLRqDsBmNlc4D8D57v7STN7ELgGuBz4qrv3mNmfA6uBO8PfE+5+npldA9wC/H7mHkxhV155ZdEh5G7XeUuKDkEkGlkngacBp5vZvwBnAEeA3wY+EpZvATaQJIDloQzwEPB1MzN394wxREFf+BKRiWZZ3n/N7EbgK8BJ4PvAjcAedz8vLJ8PPOLuF5jZQWCZux8Oy54Hlrj7K6MeswvoAmhtbV3c09NTd3xDQ0O0tLTUvX6jVBtX38BgDtH8UuvpcPRkrpusSrVxLZw7vfHBpEz211feFFdtssTV2dm5393bx2uXZQhoJsmn+nOB14C/AjL/np+7dwPdAO3t7d7R0VH3Y/X29pJl/UYZHVelUxlX5fypf+3CYW7ta74zg6uN69CKjsYHkzJZXl/NQnHVJo+4svy3fwD4e3f/RwAz+zbwXmCGmU1z92FgHjAQ2g8A84HDZjYNmE4yGRylaoZ0Dn/julJ53pp7GxlO09ib6vOSSPosUpQsCeAfgIvN7AySIaClwD5gN3AVyZlAK4Gtof22cP9vw/IfaPx/bL8YOl50CLlrjbDPIkWp+3sA7r6XZDL3AMkpoL9GMnRzE/AHZtZPciroprDKJuDsUP8HwLoMcYuISEaZBnzdfT2wflT1C8BFZdr+E/B7WbYnIiITp/lm/CKn0z1FJC+6FISISKSUAEREIqUhoAoqDcVUc8nhLOuKiORFRwAiIpHSEUCORo4M1i4cRrteRIqmIwARkUjpY2gTO2flbUWHkLsrIuyzSFGUAJrYaeecV3QIuTuYoc+jJ9816S4yNiWACaIvcInIZKMEUKNKl24WEZlslABS9CleRGISfQJo5jf9F2+5olT+jZu2FxhJfg6l+twWSZ9FihJ9AsiimZOHiMh49D0AEZFI6QhApixN2IuMTUcAIiKRivIIQGP3IiI6AhARiZYSgIhIpJQAREQipQQgIhKpTJPAZjYD+CZwAeDAx4BngQeANuAQcLW7nzAzA24HLgfeAFa5+4Es2xeplk4JFXmrrGcB3Q58z92vMrNTgTOAm4Fd7r7RzNYB64CbgMuABeG2BLgz/JUK5n56S9Eh5O6iCPssUpS6E4CZTQfeD6wCcPc3gTfNbDnQEZptAXpJEsBy4F53d2CPmc0wsznufqTu6Ke4aWedXXQIuTsWYZ9FimLJ+3EdK5pdCHQDTwPvAfYDNwID7j4jtDHghLvPMLPtwEZ3/1FYtgu4yd33jXrcLqALoLW1dXFPT09d8QEMDQ3R0tLylvq+gcG6H3MitJ4OR08WGkJZscS1cO70CXmcSq+voimu2kzFuDo7O/e7e/t47bIMAU0DFgGfcfe9ZnY7yXBPibu7mdWUYdy9mySx0N7e7h0dHXUH2NvbS7n1VxX8RbC1C4e5ta/5voMXS1yHVnRMyONUen0VTXHVJua4spwFdBg47O57w/2HSBLCUTObAxD+HgvLB4D5qfXnhTqpYPj1V0u3WLzj9VdLNxFprLo/Vrn7y2b2kpm9292fBZaSDAc9DawENoa/W8Mq24AbzKyHZPJ3UOP/Yxv4s5Wlciy/B/DjVJ/1ewAijZX1uPozwH3hDKAXgOtJjioeNLPVwIvA1aHtDpJTQPtJTgO9PuO2RUQkg0wJwN0fB8pNNCwt09aBNVm2JyIiE0ffBBYRiZQSgIhIpJQAREQipQQgIhIpJQARkUgpAYiIREoJQEQkUs134ReRBtNvA4gklACaWCyXf0jT5R9E8qMhIBGRSCkBiIhESglARCRSmgNoYv/8cn+pfNo55xUYSX4uSPX5YCR9FimKEkATe3nLZ0vlWCaEt6f6rAlhkcZSApCo6ZRQiZnmAEREIqUEICISKSUAEZFIRTMHkB7rFRERHQGIiERLCUBEJFKZE4CZnWJmf2dm28P9c81sr5n1m9kDZnZqqD8t3O8Py9uybltEROo3EUcANwLPpO7fAnzV3c8DTgCrQ/1q4ESo/2po11B9A4O0rfuuxv9FRMrIlADMbB7wQeCb4b4Bvw08FJpsAT4cysvDfcLypaG9VHBKy6zSLRZHW2aVbiLSWFnPAroN+BxwVrh/NvCauw+H+4eBuaE8F3gJwN2HzWwwtH8lYwxT1rw19xYdQu6WFNhnfStYYmPuXt+KZlcAl7v7p82sA/hDYBWwJwzzYGbzgUfc/QIzOwgsc/fDYdnzwBJ3f2XU43YBXQCtra2Le3p66ooP4NjxQY6erHv1hmk9HcVVg6LjWjh3etn6oaEhWlpaco5mfIqrNlMxrs7Ozv3u3j5euyxHAO8FPmRmlwNvB/4VcDsww8ymhaOAecBAaD8AzAcOm9k0YDrw6ugHdfduoBugvb3dOzo66g7wjvu2cmtf833VYe3CYcVVg6LjOrSio2x9b28vWV6fjaK4ahNzXHXPAbj75919nru3AdcAP3D3FcBu4KrQbCWwNZS3hfuE5T/weg8/REQks0Z8rLoJ6DGzLwN/B2wK9ZuAvzCzfuA4SdKQMbzRv7dUPuO8JQVGkp+lqT7viqTPIkWZkATg7r1Abyi/AFxUps0/Ab83EduLxT9+60ulciy/B7Ap1Wf9HoBIY+mbwCIikVICEBGJlBKAiEiklABERCKlBCAiEiklABGRSCkBiIhESglARCRSzXfhF5Emo6uEylSlBNDETm19V9Eh5K4vwj6LFEUJoInNWXV70SHk7spJ1Oe+gUFWhaMDHRnIZKQ5ABGRSCkBiIhESglARCRSmgNoYq8//r1S+awLlxUYSX6uTfX5/kj6LFIUJYAmdvzRr5fKsSSA/5HqczMmgPQpoWsXFhiIyATQEJCISKSUAEREIqUEICISKSUAEZFIaRJYZALoekEyGekIQEQkUnUnADObb2a7zexpM3vKzG4M9bPMbKeZPRf+zgz1ZmZfM7N+M3vSzBZNVCdERKR2WY4AhoG17n4+cDGwxszOB9YBu9x9AbAr3Ae4DFgQbl3AnRm2LSIiGdWdANz9iLsfCOXXgWeAucByYEtotgX4cCgvB+71xB5ghpnNqTtyERHJZEImgc2sDfgtYC/Q6u5HwqKXgdZQngu8lFrtcKg7gpR1+rv+bdEh5O5vpkCfNSEsk4W5e7YHMGsB/g/wFXf/tpm95u4zUstPuPtMM9sObHT3H4X6XcBN7r5v1ON1kQwR0draurinp6fu2I4dH+ToybpXb5jW01FcNZjMcS2cOz2fYFKGhoZoaWnJfbvjUVy1yRJXZ2fnfndvH69dpiMAM3sb8C3gPnf/dqg+amZz3P1IGOI5FuoHgPmp1eeFul/h7t1AN0B7e7t3dHTUHd8d923l1r7mO9N17cJhxVWDyRzXoRUd+QST0tvbS5b/m0ZRXLXJI64sZwEZsAl4xt3/NLVoG7AylFcCW1P114WzgS4GBlNDRSIikrMsH6veC3wU6DOzx0PdzcBG4EEzWw28CFwdlu0ALgf6gTeA6zNsW0REMqo7AYSxfKuweGmZ9g6sqXd7MXrtR/eVyjPet6LASPLz2VSfb4ukzyJFab6BVSkZ/L/3l8rRJIBUn6dCAtAZQdLMdCkIEZFIKQGIiERKQ0AiOUkPB6VpaEiKoiMAEZFIKQGIiERKCUBEJFKaAxBpIjptVPKkBCBSsEqTwyKNpiEgEZFI6QigibW859KiQ8jdX0bYZ5GiKAE0sbOXfaboEHJ3c4R9rkTzAdJoGgISEYmUEoCISKQ0BCQyCWg4SBpBCaCJvfq9O0rlWOYD/nuqz5oPKE/JQCaKEkATG3ri0VI5lgTwkVSflQDGp2QgWSgBiExBSgxSDSUAkSli5E1/7cJhxvrXVnKQEUoAIlOcLjUhlSgBiAigI4MYKQGIRKyaowP9ktnUlXsCMLNlwO3AKcA33X1j3jGIyNgmKjGk29yz7MzsgcmEyjUBmNkpwDeA/wgcBh4zs23u/nSecYhI41RKDH0Dg6wKyyolibQYjzDyTph5HwFcBPS7+wsAZtYDLAeUAEQikuUII62aJFFpbiN91tSqdd+NMuHknQDmAi+l7h8GluQcg4hMEbWe4TRW+0acLVXNkU6RzN3z25jZVcAyd/94uP9RYIm735Bq0wV0hbvvBp7NsMnZwCsZ1m8UxVUbxVUbxVWbqRjXb7j7r4/XKO8jgAFgfur+vFBX4u7dQPdEbMzM9rl7+0Q81kRSXLVRXLVRXLWJOa68Lwf9GLDAzM41s1OBa4BtOccgIiLkfATg7sNmdgPwKMlpoJvd/ak8YxARkUTu3wNw9x3Ajpw2NyFDSQ2guGqjuGqjuGoTbVy5TgKLiEjz0E9CiohEatInADNbZmbPmlm/ma0rs/w0M3sgLN9rZm05xDTfzHab2dNm9pSZ3VimTYeZDZrZ4+H2x42OK7XtQ2bWF7a7r8xyM7OvhX32pJktyiGmd6f2xeNm9jMz++yoNrnsMzPbbGbHzOxgqm6Wme00s+fC35kV1l0Z2jxnZitziOtPzOwn4Xn6jpnNqLDumM95A+LaYGYDqefq8grrjvn/24C4HkjFdMjMHq+wbiP3V9n3h0JeY+4+aW8kE8nPA+8ETgWeAM4f1ebTwJ+H8jXAAznENQdYFMpnAT8tE1cHsL2g/XYImD3G8suBRwADLgb2FvC8vkxyLnPu+wx4P7AIOJiq+5/AulBeB9xSZr1ZwAvh78xQntnguC4BpoXyLeXiquY5b0BcG4A/rOJ5HvP/d6LjGrX8VuCPC9hfZd8finiNTfYjgNKlJdz9TWDk0hJpy4EtofwQsNTMrJFBufsRdz8Qyq8Dz5B8C3qyWA7c64k9wAwzm5Pj9pcCz7v7izlus8TdfwgcH1Wdfh1tAT5cZtVLgZ3uftzdTwA7gWWNjMvdv+/uw+HuHpLv1uSqwv6qRjX/vw2JK7wHXA3cP1Hbq9YY7w+5v8YmewIod2mJ0W+0pTbhH2UQODuX6IAw5PRbwN4yi/+dmT1hZo+Y2W/mFRPgwPfNbH/45vVo1ezXRrqGyv+YRe2zVnc/EsovA61l2hS93z5GcuRWznjPeSPcEIamNlcYzihyf/0H4Ki7P1dheS77a9T7Q+6vscmeAJqambUA3wI+6+4/G7X4AMkQx3uAO4C/zjG097n7IuAyYI2ZvT/HbY/Jki8Ifgj4qzKLi9xnJZ4cizfV6XNm9gVgGLivQpO8n/M7gXcBFwJHSIZbmsm1jP3pv+H7a6z3h7xeY5M9AYx7aYl0GzObBkwHXm10YGb2NpIn9z53//bo5e7+M3cfCuUdwNvMbHaj4wrbGwh/jwHfITkUT6tmvzbKZcABdz86ekGR+ww4OjIMFv4eK9OmkP1mZquAK4AV4Y3jLap4zieUux9191+4+/8D7q6wvaL21zTgd4AHKrVp9P6q8P6Q+2tssieAai4tsQ0YmSm/CvhBpX+SiRLGFzcBz7j7n1Zoc87IXISZXUTyXOSRmM40s7NGyiSTiAdHNdsGXGeJi4HB1KFpo1X8ZFbUPgvSr6OVwNYybR4FLjGzmWHI45JQ1zCW/MDS54APufsbFdpU85xPdFzpOaP/VGF7RV0a5gPAT9z9cLmFjd5fY7w/5P8aa8Qsd543kjNWfkpyNsEXQt0XSf4hAN5OMpzQD/wYeGcOMb2P5PDtSeDxcLsc+BTwqdDmBuApkjMf9gD/Pqf99c6wzSfC9kf2WTo2I/nhnueBPqA9p9jOJHlDn56qy32fkSSgI8C/kIyxriaZN9oFPAf8DTArtG0n+WW7kXU/Fl5r/cD1OcTVTzImPPI6Gznj7V8DO8Z6zhsc11+E186TJG9sc0bHFe6/5f+3kXGF+ntGXlOptnnur0rvD7m/xvRNYBGRSE32ISAREamTEoCISKSUAEREIqUEICISKSUAEZFIKQGIiERKCUBEJFJKACIikfr/Rt25lhY0GnwAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df, hist = quantile_classify(data['conc_cf'], data['aa_seq'])\n",
+    "X, y = encode_sequence(df['aa_seq'], df['class'],\n",
+    "                       max_length=200)\n",
+    "\n",
+    "aa_model = train_clstm(X, y, test_fraction=0.3, epochs=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Novo Capstone",
+   "language": "python",
+   "name": "novo"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This PR primarily introduces a new function to train our favorite C-LSTM architecture to perform classification on amino acid sequence. Includes several updates to the repo:

- `train_clstm` function in the new `predict.py` file
- `train_clstm_example.ipynb` example notebook
- `documentize_sequence` function in `data_processing.py` 

These updates provide a simple route from new data to trained, reusable model.